### PR TITLE
Fix cart add simple and variable products

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1966,13 +1966,28 @@ add_action('wp_ajax_woocommerce_ajax_add_to_cart', 'woocommerce_ajax_add_to_cart
 add_action('wp_ajax_nopriv_woocommerce_ajax_add_to_cart', 'woocommerce_ajax_add_to_cart');
 
 function woocommerce_ajax_add_to_cart() {
-    $product_id = apply_filters('woocommerce_add_to_cart_product_id', absint($_POST['product_id']));
-    $quantity = empty($_POST['quantity']) ? 1 : wc_stock_amount($_POST['quantity']);
-    $variation_id = absint($_POST['variation_id']);
-    $passed_validation = apply_filters('woocommerce_add_to_cart_validation', true, $product_id, $quantity);
-    $product_status = get_post_status($product_id);
+    // Support both catalog buttons (product_id) and single product forms (add-to-cart)
+    $product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
+    if (!$product_id && isset($_POST['add-to-cart'])) {
+        $product_id = absint($_POST['add-to-cart']);
+    }
+    $product_id = apply_filters('woocommerce_add_to_cart_product_id', $product_id);
 
-    if ($passed_validation && WC()->cart->add_to_cart($product_id, $quantity, $variation_id) && 'publish' === $product_status) {
+    $quantity     = empty($_POST['quantity']) ? 1 : wc_stock_amount($_POST['quantity']);
+    $variation_id = isset($_POST['variation_id']) ? absint($_POST['variation_id']) : 0;
+
+    // Collect chosen variation attributes if present
+    $variation = array();
+    foreach ($_POST as $key => $value) {
+        if (strpos($key, 'attribute_') === 0 && $value !== '') {
+            $variation[$key] = wc_clean(wp_unslash($value));
+        }
+    }
+
+    $passed_validation = apply_filters('woocommerce_add_to_cart_validation', true, $product_id, $quantity);
+    $product_status    = $product_id ? get_post_status($product_id) : false;
+
+    if ($product_id && $passed_validation && WC()->cart->add_to_cart($product_id, $quantity, $variation_id, $variation) && 'publish' === $product_status) {
         do_action('woocommerce_ajax_added_to_cart', $product_id);
 
         if ('yes' === get_option('woocommerce_cart_redirect_after_add')) {
@@ -1982,8 +1997,8 @@ function woocommerce_ajax_add_to_cart() {
         WC_AJAX::get_refreshed_fragments();
     } else {
         $data = array(
-            'error' => true,
-            'product_url' => apply_filters('woocommerce_cart_redirect_after_error', get_permalink($product_id), $product_id)
+            'error'       => true,
+            'product_url' => $product_id ? apply_filters('woocommerce_cart_redirect_after_error', get_permalink($product_id), $product_id) : home_url('/'),
         );
         echo wp_send_json($data);
     }
@@ -2023,14 +2038,20 @@ function ajax_cart_notifications_script() {
 
         // Обработчик для кнопок добавления в корзину в каталоге
         $(document).on('click', '.ajax_add_to_cart', function(e) {
-            e.preventDefault();
-            
             var $thisbutton = $(this);
             var $form = $thisbutton.closest('form.cart');
+
+            // Если клик внутри формы на странице товара, не перехватываем (пусть обрабатывает submit ниже)
+            if ($form.length) {
+                return; // не вызываем preventDefault
+            }
+
+            e.preventDefault();
+
             var id = $thisbutton.val();
-            var product_qty = $form.find('input[name=quantity]').val() || 1;
-            var product_id = $form.length ? $form.find('input[name=product_id]').val() || id : id;
-            var variation_id = $form.find('input[name=variation_id]').val() || 0;
+            var product_qty = 1;
+            var product_id = id;
+            var variation_id = 0;
 
             var data = {
                 action: 'woocommerce_ajax_add_to_cart',


### PR DESCRIPTION
Fixes AJAX add-to-cart for simple products on single pages and prevents double additions for variable products.

The custom AJAX handler was not correctly processing `add-to-cart` requests from single product pages for simple products, and its JavaScript click handler was conflicting with the default form submission for variable products, leading to duplicate additions.

---
<a href="https://cursor.com/background-agent?bcId=bc-efd66693-ac53-4673-9a13-2d03e6743320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efd66693-ac53-4673-9a13-2d03e6743320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

